### PR TITLE
cursor-gpt5-codex-max_draft/support-responses-api

### DIFF
--- a/server/sample_agents.py
+++ b/server/sample_agents.py
@@ -31,7 +31,7 @@ class YodaLLM(CustomLLM):
     TODO Docstring
     """
 
-    def __init__(self, *, target_model: str = "openai/gpt-5-codex", **kwargs: Any) -> None:
+    def __init__(self, *, target_model: str = "openai/gpt-4o", **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.target_model = target_model
 
@@ -58,11 +58,6 @@ class YodaLLM(CustomLLM):
             messages = messages + [_YODA_SYSTEM_PROMPT]
 
             optional_params["stream"] = False
-            # TODO Is it even sensible to try and adapt the incoming params to the outbound call ?
-            #  Maybe just ignore them altogether ?
-            optional_params.pop("max_tokens", None)
-            optional_params.pop("temperature", None)
-
             # For Langfuse
             optional_params.setdefault("metadata", {}).setdefault("trace_name", "OUTBOUND-from-completion")
 
@@ -121,11 +116,6 @@ class YodaLLM(CustomLLM):
             messages = messages + [_YODA_SYSTEM_PROMPT]
 
             optional_params["stream"] = False
-            # TODO Is it even sensible to try and adapt the incoming params to the outbound call ?
-            #  Maybe just ignore them altogether ?
-            optional_params.pop("max_tokens", None)
-            optional_params.pop("temperature", None)
-
             # For Langfuse
             optional_params.setdefault("metadata", {}).setdefault("trace_name", "OUTBOUND-from-acompletion")
 
@@ -184,11 +174,6 @@ class YodaLLM(CustomLLM):
             messages = messages + [_YODA_SYSTEM_PROMPT]
 
             optional_params["stream"] = True
-            # TODO Is it even sensible to try and adapt the incoming params to the outbound call ?
-            #  Maybe just ignore them altogether ?
-            optional_params.pop("max_tokens", None)
-            optional_params.pop("temperature", None)
-
             # For Langfuse
             optional_params.setdefault("metadata", {}).setdefault("trace_name", "OUTBOUND-from-streaming")
 
@@ -248,11 +233,6 @@ class YodaLLM(CustomLLM):
             messages = messages + [_YODA_SYSTEM_PROMPT]
 
             optional_params["stream"] = True
-            # TODO Is it even sensible to try and adapt the incoming params to the outbound call ?
-            #  Maybe just ignore them altogether ?
-            optional_params.pop("max_tokens", None)
-            optional_params.pop("temperature", None)
-
             # For Langfuse
             optional_params.setdefault("metadata", {}).setdefault("trace_name", "OUTBOUND-from-astreaming")
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -594,8 +594,8 @@ def _try_parse_responses_chunk(chunk: Any) -> Optional[dict[str, Any]]:
             if arguments is not None and not isinstance(arguments, str):
                 try:
                     arguments = str(arguments)
-                except Exception:  # pylint: disable=broad-except
-                    arguments = None
+                except Exception as e:
+                    raise RuntimeError("Failed to convert Responses tool_call arguments to string") from e
             call_id = payload.get("id") or payload.get("call_id") or payload.get("tool_call_id")
             tool_use = {
                 "index": index,
@@ -797,8 +797,8 @@ def _convert_responses_tool_call(payload: dict[str, Any]) -> Optional[dict[str, 
         else:
             try:
                 arguments = json.dumps(raw_arguments)
-            except Exception:  # pylint: disable=broad-except
-                arguments = None
+            except Exception as e:
+                raise RuntimeError("Failed to JSON-encode Responses tool_call arguments") from e
     else:
         arguments = str(raw_arguments) if raw_arguments is not None else None
 


### PR DESCRIPTION
PROMPT:

Please take a look at @server/sample_agents.py. As you can see, apart from Completions API, Responses API is also used there via LiteLLM. This is currently broken because the messages that are fed into Responses API are actually in Completions API format.

Please take a look at the following migration guide by OpenAI: @migration-to-responses/MIGRATE_TO_RESPONSES.md. You task is to implement a function that converts messages from Completions API format to Responses API format.

NOTE: The guide doesn't elaborate on cases when the message `content` is not a string but a list of other dictionaries with media of different types (`text`, `image`, etc.) You will need to take care of these cases too, and you will have to use your own knowledge and understanding to do that (like changing `text` to `input_text` and so on).

Please put the conversion function into @server/utils.py

A LOT OF FOLLOW-UPS AFTER THAT